### PR TITLE
Add interfaces for predefined headers and claims

### DIFF
--- a/src/Algorithm.php
+++ b/src/Algorithm.php
@@ -2,6 +2,9 @@
 
 namespace Firehed\JWT;
 
+/**
+ * Constants for algorithm header parameter values in RFC7518 Section 3.1
+ */
 interface Algorithm
 {
     const NONE = 'none';

--- a/src/Claim.php
+++ b/src/Claim.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\JWT;
+
+/**
+ * Constants for registered claims in RFC7519 Section 4.1
+ */
+interface Claim
+{
+    public const ISSUER = 'iss'; // 4.1.1
+    public const SUBJECT = 'sub'; // 4.1.2
+    public const AUDIENCE = 'aud'; // 4.1.3
+    public const EXPIRATION_TIME = 'exp'; // 4.1.4
+    public const NOT_BEFORE = 'nbf'; // 4.1.5
+    public const ISSUED_AT = 'iat'; // 4.1.6
+    public const JWT_ID = 'jti'; // 4.1.7
+}

--- a/src/Header.php
+++ b/src/Header.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\JWT;
+
+/**
+ * Constants for registered header parameter names in RFC7515 Section 4.1
+ */
+class Header
+{
+    public const ALGORITHM = 'alg'; // 4.1.1
+    public const JWK_SET_URL = 'jku'; // 4.1.2
+    public const JSON_WEB_KEY = 'jwk'; // 4.1.3
+    public const KEY_ID = 'kid'; // 4.1.4
+    public const X509_URL = 'x5u'; // 4.1.5
+    public const X509_CERT_CHAIN = 'x5c'; // 4.1.6
+    public const X509_CERT_SHA1_THUMBPRINT = 'x5t'; // 4.1.7
+    public const X509_CERT_SHA256_THUMBPRINT = 'x5t#S256'; // 4.1.8
+    public const TYPE = 'typ'; // 4.1.9
+}

--- a/src/Header.php
+++ b/src/Header.php
@@ -7,7 +7,7 @@ namespace Firehed\JWT;
 /**
  * Constants for registered header parameter names in RFC7515 Section 4.1
  */
-class Header
+interface Header
 {
     public const ALGORITHM = 'alg'; // 4.1.1
     public const JWK_SET_URL = 'jku'; // 4.1.2

--- a/src/SessionHandler.php
+++ b/src/SessionHandler.php
@@ -107,10 +107,10 @@ class SessionHandler implements SessionHandlerInterface
     public function write($session_id, $session_data): bool
     {
         $data = [
-            'jti' => $session_id,
+            Claim::JWT_ID => $session_id,
 //            future considerations:
-//            'nbf' => not before,
-//            'exp' => expires,
+//            Claim::NOT_BEFORE => not before,
+//            Claim::EXPIRATION_TIME => expires,
             self::CLAIM => $session_data,
         ];
         $jwt = (new JWT($data))

--- a/tests/SessionHandlerTest.php
+++ b/tests/SessionHandlerTest.php
@@ -47,7 +47,6 @@ class SessionHandlerTest extends \PHPUnit\Framework\TestCase
 
     public function testGC(): void
     {
-        // @phpstan-ignore-next-line PHPStan has the wrong type info for the handler
         self::assertSame(0, $this->handler->gc(1));
     }
 


### PR DESCRIPTION
This adds some constants corresponding to predefined values in the RFCs that define JWTs. While consumers of this library do not need to use these constants, they add additional readability to code producing or consuming JWTs & help add clarity as to what values belong in headers vs claims.