### PR TITLE
Add and test codec

### DIFF
--- a/src/Codec.php
+++ b/src/Codec.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\JWT;
+
+/**
+ * Convenience wrapper for key management. The intent is to set up an instance
+ * of this class once in your application's DI container, and pass it around
+ * (rather than the key container) for all operations.
+ */
+class Codec
+{
+    private KeyContainer $keys;
+
+    public function __construct(KeyContainer $keys)
+    {
+        $this->keys = $keys;
+    }
+
+    /**
+     * @param array<string, mixed> $claims
+     * @param int|string|null $keyId
+     */
+    public function encode(array $claims, $keyId = null): string
+    {
+        $jwt = new JWT($claims);
+        $jwt->setKeys($this->keys);
+        return $jwt->getEncoded($keyId);
+    }
+
+    public function decode(string $jwt): JWT
+    {
+        return JWT::fromEncoded($jwt, $this->keys);
+    }
+}

--- a/tests/CodecTest.php
+++ b/tests/CodecTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\JWT;
+
+use Firehed\Security\Secret;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers Codec
+ */
+class CodecTest extends TestCase
+{
+    private Codec $codec;
+    private KeyContainer $container;
+
+    public function setUp(): void
+    {
+        $keyContainer = new KeyContainer();
+        $keyContainer->addKey('a', Algorithm::HMAC_SHA_256, new Secret('key-a'));
+        $keyContainer->addKey('b', Algorithm::HMAC_SHA_384, new Secret('key-b'));
+        $keyContainer->addKey('c', Algorithm::HMAC_SHA_512, new Secret('key-c'));
+        $this->codec = new Codec($keyContainer);
+        $this->container = $keyContainer;
+    }
+
+    public function testRoundtrip(): void
+    {
+        $claims = [
+            Claim::ISSUED_AT => time(),
+        ];
+        $encoded = $this->codec->encode($claims);
+        $decoded = $this->codec->decode($encoded);
+
+        self::assertSame($claims, $decoded->getClaims());
+        self::assertSame('c', $decoded->getKeyID());
+    }
+
+    public function testRoundtripWithSpecifiedKeyId(): void
+    {
+        $this->container->setDefaultKey('a');
+        $claims = [
+            Claim::ISSUED_AT => time(),
+        ];
+        $encoded = $this->codec->encode($claims, 'b');
+        $decoded = $this->codec->decode($encoded);
+
+        self::assertSame($claims, $decoded->getClaims());
+        self::assertSame('b', $decoded->getKeyID());
+    }
+
+    public function testRoundtripWithContainerDefaultKeyId(): void
+    {
+        $this->container->setDefaultKey('a');
+        $claims = [
+            Claim::ISSUED_AT => time(),
+        ];
+        $encoded = $this->codec->encode($claims);
+        $decoded = $this->codec->decode($encoded);
+
+        self::assertSame($claims, $decoded->getClaims());
+        self::assertSame('a', $decoded->getKeyID());
+    }
+}


### PR DESCRIPTION
This is intended as a convenience tool to avoid having to work with too many classes in too many places. It aims to simplify the end-user API. See #10.